### PR TITLE
Populate library.properties url field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Rob Starling <github@robstarling.org>
 sentence=Decode the signal received by a wireless temperature sensor's base unit.
 paragraph=.
 category=Sensors
-url=.
+url=https://github.com/robstarling/ArduRight
 architectures=avr


### PR DESCRIPTION
A empty/invalid url field results in an apparently clickable "More info" link in Library Manager that does nothing.